### PR TITLE
Better digit conversion

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,19 +1,17 @@
+use std::convert::TryInto;
 use std::str;
 use std::str::FromStr;
-use std::convert::TryInto;
 
-const TURKISHID_LENGTH : usize = 11;
+const TURKISHID_LENGTH: usize = 11;
 
 /// Turkish citizenship ID number.
-#[derive(Eq)]
-#[derive(Debug)]
+#[derive(Eq, Debug)]
 pub struct TurkishId {
     value: [u8; TURKISHID_LENGTH],
 }
 
 /// Represents the parser error for a given Turkish citizenship ID number.
-#[derive(Debug)]
-#[derive(PartialEq)]
+#[derive(Debug, PartialEq)]
 pub enum TurkishIdError {
     InvalidLength,
     InvalidChecksum,
@@ -21,15 +19,15 @@ pub enum TurkishIdError {
 
 impl TurkishId {
     /// Create a new `TurkishId` from a string.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `value` - The string that contains the ID number.
-    /// 
+    ///
     /// # Example
     /// ```rust
     /// use trid::TurkishId;
-    /// 
+    ///
     /// let id = TurkishId::new("76558242278");
     pub fn new(value: &str) -> Self {
         if !is_valid(&value) {
@@ -39,36 +37,41 @@ impl TurkishId {
     }
 
     fn new_internal(value: &str) -> Self {
-        TurkishId { value: value.as_bytes().try_into().expect("Internal error: incorrect length") }
+        TurkishId {
+            value: value
+                .as_bytes()
+                .try_into()
+                .expect("Internal error: incorrect length"),
+        }
     }
 }
 
 /// Checks if the given string is a valid Turkish citizenship ID number.
-/// 
+///
 /// # Arguments
-/// 
+///
 /// * `value` - The string to check.
-/// 
+///
 /// # Returns
-/// 
+///
 /// `true` if the string is a valid Turkish ID number, `false` otherwise.
-/// 
+///
 /// # Example
 /// ```
 /// use trid;
-/// 
+///
 /// assert!(trid::is_valid("76558242278"));
 /// ```
-/// 
+///
 /// ```
 /// use trid;
-/// 
+///
 /// assert!(!trid::is_valid("06558242278"));
 /// ```
 pub fn is_valid(value: &str) -> bool {
     let digits = value.as_bytes();
     if digits.len() != TURKISHID_LENGTH {
-        return false
+        return false;
     }
 
     let mut invalid = false;
@@ -82,7 +85,7 @@ pub fn is_valid(value: &str) -> bool {
         even_sum += digit(digits[i], &mut invalid);
         odd_sum += digit(digits[i + 1], &mut invalid);
     }
-    
+
     let first_checksum = digit(digits[9], &mut invalid);
     let final_checksum = digit(digits[10], &mut invalid);
     if invalid {
@@ -119,7 +122,9 @@ impl PartialEq for TurkishId {
 
 impl ToString for TurkishId {
     fn to_string(&self) -> String {
-        str::from_utf8(&self.value).expect("Invalid value").to_string()
+        str::from_utf8(&self.value)
+            .expect("Invalid value")
+            .to_string()
     }
 }
 
@@ -127,22 +132,22 @@ impl FromStr for TurkishId {
     type Err = TurkishIdError;
 
     /// Returns `TurkishId` from a string if it's valid, otherwise returns `TurkishIdError`.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `value` - The string that contains the ID number.
-    /// 
+    ///
     /// # Returns
-    /// 
+    ///
     /// * `Ok(TurkishId)` - If the ID number is valid.
     /// * `Err(TurkishIdError)` - If the ID number is invalid.
-    /// 
+    ///
     /// # Example
-    /// 
+    ///
     /// ```
     /// use trid::TurkishId;
     /// use trid::TurkishIdError;
-    /// 
+    ///
     /// let id : Result<TurkishId, TurkishIdError> = "76558242278".parse();
     /// assert_eq!(id, Ok(trid::TurkishId::new("76558242278")));
     /// ```
@@ -150,7 +155,7 @@ impl FromStr for TurkishId {
     /// ```
     /// use trid::TurkishId;
     /// use trid::TurkishIdError;
-    /// 
+    ///
     /// let result : Result<TurkishId, TurkishIdError> = "6558242278".parse();
     /// assert_eq!(result, Err(trid::TurkishIdError::InvalidLength));
     /// ```
@@ -164,5 +169,5 @@ impl FromStr for TurkishId {
         }
 
         Ok(Self::new_internal(&s))
-   }
+    }
 }

--- a/tests/is_valid.rs
+++ b/tests/is_valid.rs
@@ -1,6 +1,6 @@
 extern crate trid;
 
-const VALID_NUMBERS : &[&'static str] = &[
+const VALID_NUMBERS: &[&'static str] = &[
     "19191919190",
     "76558242278",
     "80476431508",
@@ -15,11 +15,10 @@ const VALID_NUMBERS : &[&'static str] = &[
     "64404737702",
 ];
 
-const INVALID_NUMBERS : &[&'static str] = &[
+const INVALID_NUMBERS: &[&'static str] = &[
     "04948892948", // first digit zero
     "14948892946", // last digit INVALID
     "14948892937", // last second digit INVALID
-
     // non numeric chars
     "A4948892948",
     "7B558242278",
@@ -32,7 +31,6 @@ const INVALID_NUMBERS : &[&'static str] = &[
     "93212606I04",
     "352014085J8",
     "3520140853K",
-
     // uneven length
     "7",
     "76",
@@ -43,7 +41,6 @@ const INVALID_NUMBERS : &[&'static str] = &[
     "765582422",
     "7655824227",
     "765582422781",
-
     // spaces
     " 765582422781",
     "765582422781 ",


### PR DESCRIPTION
`to_digit` method of `char` is used instead a custom conversion method, and the calculation is not interleaved with the conversion: The conversion and validation of digits are handled first, then the calculation is done.

In addition, `cargo fmt` is applied.